### PR TITLE
fix: avoid using `asyncio.get_event_loop`

### DIFF
--- a/pagermaid/__main__.py
+++ b/pagermaid/__main__.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 from sys import path, platform
 from os import sep
 from importlib import import_module
@@ -55,4 +57,5 @@ async def main():
     await bot.stop()
 
 
-bot.run(main())
+with contextlib.closing(asyncio.new_event_loop()):
+    bot.run(main())

--- a/utils/gensession.py
+++ b/utils/gensession.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 from sys import executable, exit
 
@@ -51,5 +52,5 @@ async def main():
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    with contextlib.closing(asyncio.new_event_loop()) as loop:
+        loop.run_until_complete(main())


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into master unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

#41

The behaviour of creating a new event loop if one doesn't already exist was removed in Python 3.12 alpha and was allegedly deprecated before then.

> The [get_event_loop()](https://docs.python.org/3.12/library/asyncio-eventloop.html#asyncio.get_event_loop) method of the default event loop policy now emits a [DeprecationWarning](https://docs.python.org/3.12/library/exceptions.html#DeprecationWarning) if there is no current event loop set and it decides to create one. (Contributed by Serhiy Storchaka and Guido van Rossum in [gh-100160](https://github.com/python/cpython/issues/100160).)

(see https://docs.python.org/3.12/whatsnew/3.12.html#deprecated)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
