### PR TITLE
更轻量的基于 alpine 的 Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,8 +10,8 @@ COPY ./ /pagermaid/workdir
 
 RUN apk add --no-cache git bash imagemagick libmagic curl tzdata neofetch libzbar figlet fortune openssl tini \
     && apk add --no-cache --update --virtual .build-deps gcc python3-dev musl-dev linux-headers \
+    && git config --global pull.ff only \
     && pip install -r requirements.txt \
-    && apk del .build-deps \
-    && git config --global --add safe.directory /pagermaid/workdir
+    && apk del .build-deps
 
 ENTRYPOINT ["tini","--","bash","utils/docker-config.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,17 @@
+FROM python:alpine
+
+ENV PAGERMAID_DIR=/pagermaid
+ENV TZ=Asia/Shanghai
+ENV SHELL=/bin/bash
+
+WORKDIR /pagermaid/workdir
+
+COPY ./ /pagermaid/workdir
+
+RUN apk add --no-cache git bash imagemagick libmagic curl tzdata neofetch libzbar figlet fortune openssl tini \
+    && apk add --no-cache --update --virtual .build-deps gcc python3-dev musl-dev linux-headers \
+    && pip install -r requirements.txt \
+    && apk del .build-deps \
+    && git config --global --add safe.directory /pagermaid/workdir
+
+ENTRYPOINT ["tini","--","bash","utils/docker-config.sh"]


### PR DESCRIPTION
基于 Alpine 的 Dockerfile，构建以后 image 只有 210MB。

出于轻量化考虑，没有包括 ffmpeg 和 tesseract-ocr，需要的用户可以用 docker exec <容器名> apk add ffmpeg 的方式自行安装。

## Description

Please carefully read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into master unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
