### PR TITLE
feat: display topic title and ID in forum group

### DIFF
--- a/pagermaid/modules/message.py
+++ b/pagermaid/modules/message.py
@@ -28,10 +28,9 @@ async def userid(message: Message):
             text += f"username: @{msg_from.username}" + "\n"
     if msg_from.type in [ChatType.SUPERGROUP, ChatType.CHANNEL]:
         text += f"title: `{msg_from.title}" + "`\n"
-        if msg_from.is_forum:
-            text += f"topic title: `{message.topic.title}`\n"
-            if message.message_thread_id is not None:
-                text += f"topic ID: `{message.message_thread_id}`\n"
+        if msg_from.topic:
+            text += f"topic title: `{msg_from.topic.title}`\n"
+            text += f"topic ID: `{msg_from.topic.id}`\n"
         try:
             if msg_from.username:
                 text += f"username: @{msg_from.username}" + "\n"

--- a/pagermaid/modules/message.py
+++ b/pagermaid/modules/message.py
@@ -28,6 +28,10 @@ async def userid(message: Message):
             text += f"username: @{msg_from.username}" + "\n"
     if msg_from.type in [ChatType.SUPERGROUP, ChatType.CHANNEL]:
         text += f"title: `{msg_from.title}" + "`\n"
+        if msg_from.is_forum:
+            text += f"topic title: `{message.topic.title}`\n"
+            if message.message_thread_id is not None:
+                text += f"topic ID: `{message.message_thread_id}`\n"
         try:
             if msg_from.username:
                 text += f"username: @{msg_from.username}" + "\n"


### PR DESCRIPTION
## Description

For the groups that enable the topic function, display the topic title and ID when using `,id` command.

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
