### PR TITLE
:bug: Message deleted by mistake while executing prune in General topic

### DIFF
--- a/pagermaid/modules/prune.py
+++ b/pagermaid/modules/prune.py
@@ -25,9 +25,9 @@ async def prune(client: Client, message: Message):
     messages = []
     count = 0
     limit = message.id - message.reply_to_message.id + 1
-    if message.message_thread_id:
+    if message.topic is not None:
         func = client.get_discussion_replies(
-            input_chat, message.message_thread_id, limit=limit
+            input_chat, message.topic.id, limit=limit
         )
     else:
         func = client.get_chat_history(input_chat, limit=limit)


### PR DESCRIPTION
在Topic Group中的General下执行`prune`指令，会错误地将所有话题下的消息都删除，而不是仅删除在General中的消息。
对于General Topic下的消息，`message.message_thread_id`为`None`，而`message.topic.id`为`1`

## Summary by Sourcery

Bug Fixes:
- Fix a bug where pruning messages in a general topic would delete all messages in the topic group instead of just the messages in the general topic.