### PR TITLE
:sparkles: Add permission group rename feature

### DIFF
--- a/languages/built-in/en.yml
+++ b/languages/built-in/en.yml
@@ -453,6 +453,7 @@ sudo_group_add_user: Add this user to this permission group successfully.
 sudo_group_del_user: Successfully removed this user from this permission group.
 sudo_group_add_per: Successfully added this permission to this permission group.
 sudo_group_del_per: Successfully removed this permission from this permission group.
+sudo_group_rename_per: Successfully renamed this permission group.
 sudo_user_add_per: This permission was added to this user.
 sudo_user_del_per: Successfully removed this permission from this user.
 sudo_list: 'Sudo Administrator List:'

--- a/languages/built-in/ja.yml
+++ b/languages/built-in/ja.yml
@@ -453,6 +453,7 @@ sudo_group_add_user: Add this user to this permission group successfully.
 sudo_group_del_user: Successfully removed this user from this permission group.
 sudo_group_add_per: 一つのグループSuccessfully added this perission to this permission - グループ。
 sudo_group_del_per: Successfully removed this perission from this permission グループ。
+sudo_group_rename_per: Successfully renamed this permission グループ。
 sudo_user_add_per: This permissionwas added to this
 sudo_user_del_per: Successfully removed this perission from this user.
 sudo_list: 'Sudo Administrator List:'

--- a/languages/built-in/zh-cn.yml
+++ b/languages/built-in/zh-cn.yml
@@ -453,6 +453,7 @@ sudo_group_add_user: 添加此用户到此权限组成功
 sudo_group_del_user: 从此权限组删除此用户成功
 sudo_group_add_per: 从此权限组中添加此权限成功
 sudo_group_del_per: 从此权限组中移除此权限成功
+sudo_group_rename_per: 重命名此权限组成功
 sudo_user_add_per: 从此用户中添加此权限成功
 sudo_user_del_per: 从此用户中移除此权限成功
 sudo_list: 'Sudo 管理员列表：'

--- a/languages/built-in/zh-tw.yml
+++ b/languages/built-in/zh-tw.yml
@@ -453,6 +453,7 @@ sudo_group_add_user: 添加此用戶到此權限組成功
 sudo_group_del_user: 從此權限組刪除此用戶成功
 sudo_group_add_per: 從此權限組中添加此權限成功
 sudo_group_del_per: 從此權限組中移除此權限成功
+sudo_group_rename_per: 重命名此權限組成功
 sudo_user_add_per: 從此用戶中添加此權限成功
 sudo_user_del_per: 從此用戶中移除此權限成功
 sudo_list: 'Sudo 管理員列表：'

--- a/pagermaid/group_manager.py
+++ b/pagermaid/group_manager.py
@@ -101,3 +101,16 @@ def remove_permission_for_user(user: str, permission: Permission):
     for i in data:
         permissions.delete_permission_for_user(user, i.name, permission.act, "allow")
     permissions.save_policy()
+
+
+def rename_group(old_group: str, new_group: str):
+    users = permissions.get_users_for_role(old_group)
+    for user in users:
+        permissions.add_role_for_user(user, new_group)
+        permissions.delete_role_for_user(user, old_group)
+
+    old_policies = permissions.get_filtered_policy(0, old_group)
+    for policy in old_policies:
+        permissions.add_policy(new_group, policy[1], policy[2], policy[3])
+        permissions.remove_policy(old_group, policy[1], policy[2], policy[3])
+    permissions.save_policy()

--- a/pagermaid/modules/sudo.py
+++ b/pagermaid/modules/sudo.py
@@ -10,6 +10,7 @@ from pagermaid.group_manager import (
     add_permission_for_user,
     remove_permission_for_user,
     permissions,
+    rename_group,
 )
 from pagermaid.listener import listener
 from pagermaid.utils import lang
@@ -27,7 +28,7 @@ def from_msg_get_sudo_id(message: Message) -> int:
     is_plugin=False,
     command="sudo",
     need_admin=True,
-    parameters="{on|off|add|remove|gaddp|gaddu|gdelp|gdelu|glist|uaddp|udelp|list}",
+    parameters="{on|off|add|remove|gaddp|gaddu|gdelp|gdelu|glist|grename|uaddp|udelp|list}",
     description=lang("sudo_des"),
 )
 async def sudo_change(message: Message):
@@ -247,3 +248,16 @@ async def sudo_gaddp(message: Message):
 async def sudo_gdelp(message: Message):
     remove_permission_for_group(message.parameter[1], Permission(message.parameter[2]))
     return await message.edit(lang("sudo_group_del_per"))
+
+
+@sudo_change.sub_command(
+    is_plugin=False,
+    command="grename",
+    need_admin=True,
+)
+@check_parameter_length(3, False)
+async def sudo_grename(message: Message):
+    old_name = message.parameter[1]
+    new_name = message.parameter[2]
+    rename_group(old_name, new_name)
+    await message.edit(lang("sudo_group_rename_per"))


### PR DESCRIPTION
## Description

添加了sudo权限组重命名功能

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

## Summary by Sourcery

Add a new sudo subcommand to rename existing permission groups and ensure user-role assignments and policies are correctly migrated.

New Features:
- Introduce a 'grename' subcommand in sudo module to rename permission groups.

Enhancements:
- Implement rename_group function to transfer users and policies from the old group to the new group.

Documentation:
- Add confirmation messages for group renaming in all supported language files.