### PR TITLE
fix: Log can't be written to file when web is enabled

### DIFF
--- a/pagermaid/web/__init__.py
+++ b/pagermaid/web/__init__.py
@@ -78,7 +78,9 @@ class Web:
 
         self.init_web()
         self.web_server = uvicorn.Server(
-            config=uvicorn.Config(self.app, host=Config.WEB_HOST, port=Config.WEB_PORT)
+            config=uvicorn.Config(
+                self.app, host=Config.WEB_HOST, port=Config.WEB_PORT, log_config=None
+            )
         )
         server_config = self.web_server.config
         server_config.setup_event_loop()


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into master unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

## Summary by Sourcery

Bug Fixes:
- Pass log_config=None to uvicorn.Config to prevent Uvicorn from overriding existing logging setup