### PR TITLE
fix: Extra request when open web log page

### DIFF
--- a/pagermaid/web/pages/home_page.py
+++ b/pagermaid/web/pages/home_page.py
@@ -19,7 +19,6 @@ from amis import (
     Horizontal,
 )
 
-from pagermaid.config import Config
 from pagermaid.web.html import get_logo
 
 logo = Html(html=get_logo())
@@ -42,7 +41,7 @@ log_page = Log(
     operation=["stop", "showLineNumber", "filter"],
     source={
         "method": "get",
-        "url": "/pagermaid/api/log?num=${log_num | raw}",
+        "url": "/pagermaid/api/log?num=${log_num | default:100}",
     },
 )
 


### PR DESCRIPTION
## Description
<img width="100" height="50" alt="image" src="https://github.com/user-attachments/assets/0519535b-0965-48a7-ac5b-0cfa60734c09" />

Please carefully read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into master unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

## Summary by Sourcery

Prevent extra requests when opening the web log page by setting a default log_num parameter and clean up an unused import

Bug Fixes:
- Prevent extra log requests by providing a default log_num value in the web log API URL

Enhancements:
- Remove unused Config import from the home_page module