### PR TITLE
feat(_eval): make "sh" command follow the user's default shell

### DIFF
--- a/pagermaid/utils/_eval.py
+++ b/pagermaid/utils/_eval.py
@@ -1,7 +1,7 @@
+import contextlib
 import subprocess
 import os
 import shlex
-import pwd
 
 from importlib.util import find_spec
 from sys import executable
@@ -9,33 +9,26 @@ from asyncio import create_subprocess_shell
 from asyncio.subprocess import PIPE
 from typing import Optional
 
+try:
+    import pwd
+except ImportError:
+    pwd = None
+
 
 async def execute(command, pass_error=True):
     """Executes command and returns output, with the option of enabling stderr."""
 
-    # Attempt to obtain the current user's default shell from /etc/passwd.
-    # If this fails for any reason, fall back to the standard /bin/sh.
-    # The chosen shell is then launched in login mode (-l) to initialize
-    # the user's environment, including system-wide and user-specific shell
-    # configuration files such as /etc/profile, ~/.bash_profile, and ~/.bashrc
-    # Finally, the shell executes the given command (-c) with proper quoting
-    # to avoid shell injection issues.
-    # 
-    # TLDR; 
-    # This allows the executed command to automatically load the user's shell environment variables.
-    try:
-        user_shell = pwd.getpwuid(os.getuid()).pw_shell
-    except Exception:
-        user_shell = "/bin/sh"
-    
-    shell_command = f"{user_shell} -l -c {shlex.quote(command)}"
+    shell_command = None
+    if pwd is not None:
+        with contextlib.suppress(Exception):
+            user_shell = pwd.getpwuid(os.getuid()).pw_shell
+            if user_shell:
+                shell_command = f"{user_shell} -l -c {shlex.quote(command)}"
+    if not shell_command:
+        shell_command = command
 
-    # execute the user's command.
     executor = await create_subprocess_shell(
-        shell_command,
-        stdout=PIPE,
-        stderr=PIPE,
-        stdin=PIPE
+        shell_command, stdout=PIPE, stderr=PIPE, stdin=PIPE
     )
 
     stdout, stderr = await executor.communicate()

--- a/pagermaid/utils/_eval.py
+++ b/pagermaid/utils/_eval.py
@@ -1,4 +1,8 @@
 import subprocess
+import os
+import shlex
+import pwd
+
 from importlib.util import find_spec
 from sys import executable
 from asyncio import create_subprocess_shell
@@ -8,8 +12,30 @@ from typing import Optional
 
 async def execute(command, pass_error=True):
     """Executes command and returns output, with the option of enabling stderr."""
+
+    # Attempt to obtain the current user's default shell from /etc/passwd.
+    # If this fails for any reason, fall back to the standard /bin/sh.
+    # The chosen shell is then launched in login mode (-l) to initialize
+    # the user's environment, including system-wide and user-specific shell
+    # configuration files such as /etc/profile, ~/.bash_profile, and ~/.bashrc
+    # Finally, the shell executes the given command (-c) with proper quoting
+    # to avoid shell injection issues.
+    # 
+    # TLDR; 
+    # This allows the executed command to automatically load the user's shell environment variables.
+    try:
+        user_shell = pwd.getpwuid(os.getuid()).pw_shell
+    except Exception:
+        user_shell = "/bin/sh"
+    
+    shell_command = f"{user_shell} -l -c {shlex.quote(command)}"
+
+    # execute the user's command.
     executor = await create_subprocess_shell(
-        command, stdout=PIPE, stderr=PIPE, stdin=PIPE
+        shell_command,
+        stdout=PIPE,
+        stderr=PIPE,
+        stdin=PIPE
     )
 
     stdout, stderr = await executor.communicate()


### PR DESCRIPTION
Previously, the `,sh` command did not load the user's environment variables defined in /etc/profile, ~/.bash_profile, or ~/.bashrc (e.g., PATH), which could cause errors when executing commands.

This change ensures that ,sh runs commands in the user's login shell, automatically inheriting the environment.

## Summary by Sourcery

Run shell commands in the user's default login shell to automatically inherit environment variables

New Features:
- Execute commands through the user’s default shell in login mode to load profile configurations

Enhancements:
- Detect the user’s default shell via getpwuid and fall back to /bin/sh
- Wrap the command with proper quoting and use -l -c when invoking the shell