### PR TITLE
perf(logs): Replace FileHandler with RotatingFileHandler to support l…

### DIFF
--- a/pagermaid/utils/_log.py
+++ b/pagermaid/utils/_log.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 
 from coloredlogs import ColoredFormatter
 
@@ -10,8 +11,11 @@ logging_format = "%(levelname)s [%(asctime)s] [%(name)s] %(message)s"
 logging_handler = logging.StreamHandler()
 logging_handler.setFormatter(ColoredFormatter(logging_format))
 
-file_handler = logging.FileHandler(
-    filename="data/pagermaid.log.txt", mode="w", encoding="utf-8"
+file_handler = RotatingFileHandler(
+    filename="data/pagermaid.log.txt",
+    encoding="utf-8",
+    maxBytes=50 * 1024 * 1024, # 50MB
+    backupCount=1 # Only 1 backup to enable rotation
 )
 file_handler.setFormatter(logging.Formatter(logging_format))
 


### PR DESCRIPTION
…og rotation

Replace FileHandler with RotatingFileHandler and limit a single log file to a maximum of 50MB to avoid excessively large log files.

## Description

Please carefully read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into master unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

When a project runs for a long time, log files will grow indefinitely until the system runs out of space. The RotatingFileHandler class in logging.handlers can solve this problem.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/TeamPGM/PagerMaid-Pyro/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/TeamPGM/PagerMaid-Pyro/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

## Summary by Sourcery

Enhancements:
- Replace the standard file logger with a size-limited rotating file handler capped at 50MB per log file.